### PR TITLE
Fiix/Simplify Swagger UI setup for containerized environment

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,7 +7,16 @@ args_bin = []
 bin = "./tmp/main"
 cmd = "go build -o ./tmp/main ."
 delay = 1000
-exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+exclude_dir = [
+    "assets",
+    "tmp",
+    "vendor",
+    "testdata",
+    "scripts",
+    "local-dev",
+    "docs",
+    "docs/wiki",
+]
 exclude_file = []
 exclude_regex = ["_test.go"]
 exclude_unchanged = false

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -6,8 +6,6 @@ services:
     volumes:
       - .:/app
     command: air
-    environment:
-      GIN_MODE: debug
 
 volumes:
   pg_data:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
 
@@ -71,7 +70,7 @@ func NewServer(ctx context.Context) (*Server, error) {
 	s.setupMiddlewares()
 	s.setupRoutes(jwtManager, cardEncryptor)
 
-	setSwaggerInfo(s.httpServer.Addr, cfg.App.Env)
+	setSwaggerInfo(s.httpServer.Addr)
 
 	return s, nil
 }
@@ -154,25 +153,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 // setSwaggerInfo configures Swagger documentation settings for the API.
-// It sets the host based on the provided address and adjusts for local development if needed.
-func setSwaggerInfo(addr string, appEnv string) {
+func setSwaggerInfo(addr string) {
 	docs.SwaggerInfo.Title = "xPay Digital Wallet API"
 	docs.SwaggerInfo.Version = "1.0"
 	docs.SwaggerInfo.Schemes = []string{"http", "https"}
 	docs.SwaggerInfo.BasePath = "/api/v1"
 	docs.SwaggerInfo.Host = addr
-
-	if appEnv == common.AppEnvDev {
-		host, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			slog.Error("failed to split host and port", "error", err)
-			return
-		}
-
-		if host == "" {
-			docs.SwaggerInfo.Host = net.JoinHostPort("localhost", port)
-		}
-	}
 
 	slog.Info(fmt.Sprintf("Swagger Specs available at http://%s/swagger/index.html", docs.SwaggerInfo.Host))
 }

--- a/local-dev/config.yaml.example
+++ b/local-dev/config.yaml.example
@@ -1,7 +1,7 @@
 app:
   env: dev  # Options: dev, staging, production
   gin_mode: release # Options: debug, release.
-  server_address: ":8080"
+  server_address: "0.0.0.0:8080"
 
 db:
   # Use environment variables for credentials in non-local environments


### PR DESCRIPTION
- Use container address (0.0.0.0:8080) for Swagger host, or, directly passed server_address for staging and prod
- Exclude non-essential directories from Air live watching
- Consistent server_address env var across all configs.
- removed gin_mode from compose.dev.yaml, so gin_mode from config.yaml is final
